### PR TITLE
Prevent task overlay from closing on clicking card

### DIFF
--- a/workflowstreamer-ui/src/components/Task.js
+++ b/workflowstreamer-ui/src/components/Task.js
@@ -27,8 +27,7 @@ class Task extends PureComponent {
                     className="task-item"
                     onClick={this.toggleOverlay}
                 >
-                    <h3>{title}</h3>
-                    <p>{description}</p>
+                    <div>{title}</div>
                 </Card>
                 <Overlay
                     className="mid-overlay"
@@ -39,7 +38,6 @@ class Task extends PureComponent {
                     <Card
                         className="overlay-task"
                         interactive={true}
-                        onClick={this.toggleOverlay}
                     >
                         <h3>{title}</h3>
                         <p>{description}</p>


### PR DESCRIPTION
Closes #36 

* Made description only appear in overlay
* Card title not bold